### PR TITLE
hotfix: 설정 파일이 제대로 세팅되지 않는 문제 해결 

### DIFF
--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -2,7 +2,7 @@ name: Deploy to Develop Server
 
 on:
   push:
-    branches: [ "main" ]
+    branches: [ "main", "hotfix/config-properties" ]
 
 jobs:
   deploy:

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -59,6 +59,7 @@ jobs:
           
           echo "Starting new application..."
           sudo nohup java -Dspring.profiles.active=dev \
+          -Dspring.config.location=/home/ubuntu/app/application-dev.yml \
           -Duser.timezone=Asia/Seoul \
           -Dlogging.file.path=/home/ubuntu/app/logs \
           -jar /home/ubuntu/app/server.jar & 

--- a/.github/workflows/deploy-to-dev.yml
+++ b/.github/workflows/deploy-to-dev.yml
@@ -2,7 +2,7 @@ name: Deploy to Develop Server
 
 on:
   push:
-    branches: [ "main", "hotfix/config-properties" ]
+    branches: [ "main" ]
 
 jobs:
   deploy:


### PR DESCRIPTION
## 작업한 내용

### 문제 설명

dev 환경에서 AWS RDS에 연결되지 않는 문제가 있었습니다. 문제가 발생하고 info 레벨의 로그를 확인했고 결과는 아래와 같습니다. 

<img width="1468" alt="image" src="https://github.com/user-attachments/assets/d1734b81-84e9-4731-87ce-f5b6ae61c76d" />

profile은 dev로 의도한대로 설정됩니다. dev 환경의 profile은 MySQL을 사용하도록 설정되어 있습니다. 하지만 로그를 확인하면 h2가 연결되는 것을 볼 수 있어요. 이는 빌드된 jar 내부에 default 설정 파일이 실행되는 걸로 유추할 수 있어요. 

### 재현 방법

1. EC2의 /home/ubuntu/app 경로에 jar 파일을 배포합니다. 
2. EC2의 /home/ubuntu/app 경로에 application-dev.yml을 작성합니다. 
3. 동일한 EC2에 self-hosted runner를 설치하여 workflow를 실행합니다. 
4. workflow에서 springboot 애플리케이션을 실행하는 명령줄은 다음과 같습니다. 
  - `sudo nohup java -Dspring.profiles.active=dev  -Duser.timezone=Asia/Seoul -Dlogging.file.path=/home/ubuntu/app/logs -jar /home/ubuntu/app/server.jar & `

1-4를 진행하면 다음과 같이 세팅됩니다. 

<img width="472" alt="스크린샷 2025-02-05 오후 9 01 10" src="https://github.com/user-attachments/assets/eeecc58f-22d3-4a62-815f-f9eba81d1ce1" />

### 해결 방법

application-dev.yml을 스캔하지 못하는 걸로 결론을 냈습니다. [스프링 공식 문서](https://docs.spring.io/spring-boot/docs/1.0.1.RELEASE/reference/html/boot-features-external-config.html#boot-features-external-config-application-property-files)를 참고하면 외부 설정 파일을 세팅하는 우선순위는 다음과 같아요. 

1. A `/config` subdir of the current directory.
2. The current directory
3. A classpath `/config` package
4. The classpath root

 1, 3은 현재 상황에 해당되지 않고 2, 4번 규칙이 적용될 수 있어요. 그래서 /home/ubuntu 경로에 application-dev.yml을 두면 dev 설정 파일이 정상적으로 실행돼요. 저는 /home/ubuntu/app 안에서 애플리케이션 관련 코드를 모두 관리하고 싶었어요. 그래서 명령줄에 `--spring.config.name`를 추가하여 /home/ubuntu/app/application-dev.yml를 설정 파일로 쓸 수 있게 했어요. 
