### PR TITLE
fix: 로컬에서 사용하는 로거 설정

### DIFF
--- a/src/main/resources/logback-spring.xml
+++ b/src/main/resources/logback-spring.xml
@@ -88,6 +88,12 @@
     </root>
   </springProfile>
 
+  <springProfile name="local">
+    <root level="INFO">
+      <appender-ref ref="CONSOLE"/>
+    </root>
+  </springProfile>
+
   <springProfile name="dev">
     <root level="INFO">
       <appender-ref ref="ERROR-ROLLING"/>


### PR DESCRIPTION
## 작업 내용

기본으로 설정되어 있는 local 프로파일에서 스프링 애플리케이션을 실행하면 로그를 확인할 수 없는 문제가 있었습니다. 
logback 설정 파일에 local에서 사용할 로거를 설정하지 않아서 발생한 문제입니다. 

<img width="1304" alt="스크린샷 2025-02-06 오후 4 26 26" src="https://github.com/user-attachments/assets/2e08554c-8ed8-460b-ab43-7cd7140cd786" />
