### PR TITLE
fix: 더미 Basket은 조회되지 않도록 수정

### DIFF
--- a/src/main/java/kr/allcll/seatfinder/basket/Basket.java
+++ b/src/main/java/kr/allcll/seatfinder/basket/Basket.java
@@ -102,4 +102,12 @@ public class Basket extends BaseEntity {
         this.rcnt = rcnt;
         this.totRcnt = totRcnt;
     }
+
+    public boolean isNotEmpty() {
+        return !isEmpty();
+    }
+
+    public boolean isEmpty() {
+        return this.rcnt == null || this.rcnt == 0;
+    }
 }

--- a/src/main/java/kr/allcll/seatfinder/basket/BasketService.java
+++ b/src/main/java/kr/allcll/seatfinder/basket/BasketService.java
@@ -56,7 +56,13 @@ public class BasketService {
     public SubjectBasketsResponse getEachSubjectBaskets(Long subjectId) {
         Subject subject = subjectRepository.findById(subjectId)
             .orElseThrow(() -> new AllcllException(AllcllErrorCode.SUBJECT_NOT_FOUND));
-        List<Basket> baskets = basketRepository.findBySubjectId(subject.getId());
+        List<Basket> baskets = getBaskets(subject);
         return SubjectBasketsResponse.from(baskets);
+    }
+
+    private List<Basket> getBaskets(Subject subject) {
+        return basketRepository.findBySubjectId(subject.getId()).stream()
+            .filter(Basket::isNotEmpty)
+            .toList();
     }
 }

--- a/src/test/java/kr/allcll/seatfinder/basket/BasketApiTest.java
+++ b/src/test/java/kr/allcll/seatfinder/basket/BasketApiTest.java
@@ -8,6 +8,8 @@ import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.
 import java.util.List;
 import kr.allcll.seatfinder.basket.dto.BasketsEachSubject;
 import kr.allcll.seatfinder.basket.dto.BasketsResponse;
+import kr.allcll.seatfinder.basket.dto.EachDepartmentBasket;
+import kr.allcll.seatfinder.basket.dto.SubjectBasketsResponse;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -55,6 +57,52 @@ public class BasketApiTest {
             ))
         );
         MvcResult result = mockMvc.perform(get("/api/baskets")).andExpect(status().isOk()).andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("특정 관심과목 조회의 요청과 응답을 확인한다.")
+    void findBasket() throws Exception {
+        // given
+        String expected = """
+            {
+                "eachDepartmentRegisters": [
+                    {
+                        "studentBelong": "본교생",
+                        "registerDepartment": "컴퓨터공학과",
+                        "eachCount": 10
+                    }
+                ]
+            }
+            """;
+
+        // when
+        when(basketService.getEachSubjectBaskets(1L)).thenReturn(
+            new SubjectBasketsResponse(List.of(
+                new EachDepartmentBasket("본교생", "컴퓨터공학과", 10)
+            ))
+        );
+        MvcResult result = mockMvc.perform(get("/api/baskets/1")).andExpect(status().isOk()).andReturn();
+
+        // then
+        assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);
+    }
+
+    @Test
+    @DisplayName("관심과목으로 등록한 학생이 없으면, 관심과목 조회에 빈 응답을 확인한다.")
+    void findBasketEmpty() throws Exception {
+        // given
+        String expected = """
+            {
+                "eachDepartmentRegisters": []
+            }
+            """;
+
+        // when
+        when(basketService.getEachSubjectBaskets(1L)).thenReturn(new SubjectBasketsResponse(List.of()));
+        MvcResult result = mockMvc.perform(get("/api/baskets/1")).andExpect(status().isOk()).andReturn();
 
         // then
         assertThat(result.getResponse().getContentAsString()).isEqualToIgnoringWhitespace(expected);

--- a/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
+++ b/src/test/java/kr/allcll/seatfinder/basket/BasketServiceTest.java
@@ -1,5 +1,6 @@
 package kr.allcll.seatfinder.basket;
 
+import static kr.allcll.seatfinder.support.fixture.BasketFixture.createEmptyBasket;
 import static kr.allcll.seatfinder.support.fixture.SubjectFixture.createSubjectWithDepartmentCode;
 import static kr.allcll.seatfinder.support.fixture.SubjectFixture.createSubjectWithDepartmentInformation;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -344,6 +345,22 @@ class BasketServiceTest {
             ).containsExactly(
                 tuple("본교생", "컴공", 10)
             );
+    }
+
+    @Test
+    @DisplayName("과목에 대한 관심과목 담기한 인원이 없을 때는 빈 응답을 반환한다.")
+    public void emptyBasketResponse() {
+        // given
+        Subject subjectA = createSubjectWithDepartmentCode("컴공 과목A", "001234", "001", "김보예", "3210");
+        subjectRepository.save(subjectA);
+        Basket emptyBasket = createEmptyBasket(subjectA);
+        basketRepository.save(emptyBasket);
+
+        // when
+        SubjectBasketsResponse response = basketService.getEachSubjectBaskets(subjectA.getId());
+
+        // then
+        assertThat(response.eachDepartmentRegisters()).isEmpty();
     }
 
     @Test

--- a/src/test/java/kr/allcll/seatfinder/support/fixture/BasketFixture.java
+++ b/src/test/java/kr/allcll/seatfinder/support/fixture/BasketFixture.java
@@ -1,0 +1,13 @@
+package kr.allcll.seatfinder.support.fixture;
+
+import kr.allcll.seatfinder.basket.Basket;
+import kr.allcll.seatfinder.subject.Subject;
+
+public class BasketFixture {
+
+    public static Basket createEmptyBasket(Subject subject) {
+        return new Basket(subject, null, null, "", "", null, null,
+            null, null, null, null, 99, 0, 0,
+            0, 99, null, 0);
+    }
+}

--- a/src/test/java/kr/allcll/seatfinder/support/fixture/BasketFixture.java
+++ b/src/test/java/kr/allcll/seatfinder/support/fixture/BasketFixture.java
@@ -5,6 +5,11 @@ import kr.allcll.seatfinder.subject.Subject;
 
 public class BasketFixture {
 
+    /*
+        빈 Basket은 아래와 같이 생성됩니다.
+        0과 null로 초기화된 필드는 수정하면 안됩니다.
+        위 기준은 실제 API 요청으로 만들었습니다.
+     */
     public static Basket createEmptyBasket(Subject subject) {
         return new Basket(subject, null, null, "", "", null, null,
             null, null, null, null, 99, 0, 0,


### PR DESCRIPTION
## 작업 내용

- Basket 도메인 내에 더미 데이터를 구분하는 메서드(`isNotEmpty`, `isEmpty`)를 만들었어요. 
- basketRepository에서 subjectId로 검색할 때에 더미 데이터를 제외하는 필터를 추가했어요. 
- API 테스트가 없어서 추가했어요. 새로운 필터 로직에 대한 서비스 테스트도 추가했어요. 
